### PR TITLE
feat: add isOptional to DatasetSpecification

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mintproject/modelcatalog_client",
-  "version": "8.0.3-alpha.8",
+  "version": "8.0.3-alpha.9",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@mintproject/modelcatalog_client",
-      "version": "8.0.3-alpha.8",
+      "version": "8.0.3-alpha.9",
       "devDependencies": {
         "typescript": "^3.6"
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mintproject/modelcatalog_client",
-  "version": "8.0.3-alpha.8",
+  "version": "8.0.3-alpha.9",
   "description": "OpenAPI client for @mintproject/modelcatalog_client",
   "author": "OpenAPI-Generator",
   "main": "./dist/index.js",

--- a/src/models/DatasetSpecification.ts
+++ b/src/models/DatasetSpecification.ts
@@ -116,6 +116,12 @@ export interface DatasetSpecification {
      */
     position?: Array<number> | null;
     /**
+     * When true, this input is optional for the configuration. Ensemble manager will skip it during Tapis job submission if no dataset is bound, rather than failing with an error.
+     * @type {boolean}
+     * @memberof DatasetSpecification
+     */
+    isOptional?: boolean | null;
+    /**
      * identifier
      * @type {string}
      * @memberof DatasetSpecification
@@ -146,6 +152,7 @@ export function DatasetSpecificationFromJSONTyped(json: any, ignoreDiscriminator
         'isTransformedFrom': !exists(json, 'isTransformedFrom') ? undefined : (json['isTransformedFrom'] as Array<any>).map(DatasetSpecificationFromJSON),
         'hasDataTransformationSetup': !exists(json, 'hasDataTransformationSetup') ? undefined : (json['hasDataTransformationSetup'] as Array<any>).map(DataTransformationSetupFromJSON),
         'position': !exists(json, 'position') ? undefined : json['position'],
+        'isOptional': !exists(json, 'isOptional') ? undefined : json['isOptional'],
         'id': !exists(json, 'id') ? undefined : json['id'],
     };
 
@@ -182,6 +189,7 @@ export function DatasetSpecificationToJSON(value?: DatasetSpecification): any {
         'isTransformedFrom': value.isTransformedFrom === undefined ? undefined : (value.isTransformedFrom as Array<any>).map(DatasetSpecificationToJSON),
         'hasDataTransformationSetup': value.hasDataTransformationSetup === undefined ? undefined : (value.hasDataTransformationSetup as Array<any>).map(DataTransformationSetupToJSON),
         'position': value.position,
+        'isOptional': value.isOptional,
         'id': value.id,
     };
 }


### PR DESCRIPTION
## Summary
- Adds `isOptional?: boolean | null` (optional, nullable) to the `DatasetSpecification` model.
- Updates `DatasetSpecificationFromJSONTyped` to read the field and `DatasetSpecificationToJSON` to emit it.
- Bumps package version `8.0.3-alpha.8` -> `8.0.3-alpha.9`.

## Why
Upstream `mintproject/model-catalog-api` `openapi.yaml` (v2.0.0 backend) added `isOptional: boolean, nullable: true` to the `DatasetSpecification` schema. The corresponding Hasura column `modelcatalog_configuration_input.is_optional` is `boolean NOT NULL DEFAULT false`. Without native SDK support, MINT UI (`mint-ui-lit`) was monkey-patching `DatasetSpecificationFromJSON / FromJSONTyped / ToJSON` at runtime to keep the field from being stripped (see `mint-ui-lit` commit `d8caed2b9296eeac3dabc6ed977c08f66426ec34`). This PR removes the need for that workaround.

## Backward compatibility
- Field is optional and nullable; existing consumers are unaffected.
- Other fields keep their array conventions; only `isOptional` is a scalar boolean (matches the upstream spec).
- OpenAPI document version stays `v1.8.0`; addition is purely additive.

## Verification
Round-trip smoke test against built `dist/`:

    ToJSON({ id: 'x', label: ['L'], isOptional: true })
      -> { label: ['L'], isOptional: true, id: 'x' }
    FromJSON({ id: 'x', isOptional: true })
      -> { isOptional: true, id: 'x' }
    FromJSON({ id: 'y', isOptional: false })
      -> { isOptional: false, id: 'y' }   // false preserved
    FromJSON({ id: 'z' })
      -> { id: 'z' }                       // undefined when missing

`dist/models/DatasetSpecification.d.ts` and `.js` both contain `isOptional`. `npm run build` clean.

## Test plan
- [ ] Publish `8.0.3-alpha.9` to the npm registry
- [ ] Bump `@mintproject/modelcatalog_client` in `mint-ui-lit` and remove `src/model-catalog-api/sdk-patches.ts`
- [ ] Verify `mint-ui-lit` CI green