### PR TITLE
feat: add isOptional to DatasetSpecification

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mintproject/modelcatalog_client",
-  "version": "8.0.3-alpha.8",
+  "version": "8.0.3-alpha.9",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@mintproject/modelcatalog_client",
-      "version": "8.0.3-alpha.8",
+      "version": "8.0.3-alpha.9",
       "devDependencies": {
         "typescript": "^3.6"
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mintproject/modelcatalog_client",
-  "version": "8.0.3-alpha.8",
+  "version": "8.0.3-alpha.9",
   "description": "OpenAPI client for @mintproject/modelcatalog_client",
   "author": "OpenAPI-Generator",
   "main": "./dist/index.js",

--- a/src/models/DatasetSpecification.ts
+++ b/src/models/DatasetSpecification.ts
@@ -116,6 +116,12 @@ export interface DatasetSpecification {
      */
     position?: Array<number> | null;
     /**
+     * When true, this input is optional for the configuration. Ensemble manager will skip it during Tapis job submission if no dataset is bound, rather than failing with an error.
+     * @type {boolean}
+     * @memberof DatasetSpecification
+     */
+    isOptional?: boolean | null;
+    /**
      * identifier
      * @type {string}
      * @memberof DatasetSpecification
@@ -146,6 +152,7 @@ export function DatasetSpecificationFromJSONTyped(json: any, ignoreDiscriminator
         'isTransformedFrom': !exists(json, 'isTransformedFrom') ? undefined : (json['isTransformedFrom'] as Array<any>).map(DatasetSpecificationFromJSON),
         'hasDataTransformationSetup': !exists(json, 'hasDataTransformationSetup') ? undefined : (json['hasDataTransformationSetup'] as Array<any>).map(DataTransformationSetupFromJSON),
         'position': !exists(json, 'position') ? undefined : json['position'],
+        'isOptional': !exists(json, 'isOptional') ? undefined : json['isOptional'],
         'id': !exists(json, 'id') ? undefined : json['id'],
     };
 
@@ -182,6 +189,7 @@ export function DatasetSpecificationToJSON(value?: DatasetSpecification): any {
         'isTransformedFrom': value.isTransformedFrom === undefined ? undefined : (value.isTransformedFrom as Array<any>).map(DatasetSpecificationToJSON),
         'hasDataTransformationSetup': value.hasDataTransformationSetup === undefined ? undefined : (value.hasDataTransformationSetup as Array<any>).map(DataTransformationSetupToJSON),
         'position': value.position,
+        'isOptional': value.isOptional,
         'id': value.id,
     };
 }


### PR DESCRIPTION
## Summary
- Add `isOptional` field to `DatasetSpecification` model (boolean, nullable)
- When true, ensemble manager skips the input during Tapis job submission if no dataset is bound, rather than failing
- Bump version to 8.0.3-alpha.9

## Test plan
- [ ] Verify generated client compiles
- [ ] Confirm `isOptional` round-trips through `FromJSONTyped` / `ToJSON`
- [ ] Verify ensemble-manager consumes the new field correctly